### PR TITLE
Share X and Y axis across rows and cols

### DIFF
--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -116,23 +116,23 @@ class BrokenAxes:
         self.fig.add_subplot(self.big_ax)
 
         # get last axs row and first col
-        last_row = []
-        first_col = []
+        self.last_row = []
+        self.first_col = []
         for ax in self.axs:
             if ax.is_last_row():
-                last_row.append(ax)
+                self.last_row.append(ax)
             if ax.is_first_col():
-                first_col.append(ax)
+                self.first_col.append(ax)
 
         # Set common x/y lim for ax in the same col/row
         # and share x and y between them
         for i, ax in enumerate(self.axs):
             if ylims is not None:
                 ax.set_ylim(ylims[::-1][i//ncols])
-                ax.get_shared_y_axes().join(ax, first_col[i // ncols])
+                ax.get_shared_y_axes().join(ax, self.first_col[i // ncols])
             if xlims is not None:
                 ax.set_xlim(xlims[i % ncols])
-                ax.get_shared_x_axes().join(ax, last_row[i % ncols])
+                ax.get_shared_x_axes().join(ax, self.last_row[i % ncols])
         self.standardize_ticks()
         if d:
             self.draw_diags()

--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -115,11 +115,24 @@ class BrokenAxes:
             self.axs.append(ax)
         self.fig.add_subplot(self.big_ax)
 
+        # get last axs row and first col
+        last_row = []
+        first_col = []
+        for ax in self.axs:
+            if ax.is_last_row():
+                last_row.append(ax)
+            if ax.is_first_col():
+                first_col.append(ax)
+
+        # Set common x/y lim for ax in the same col/row
+        # and share x and y between them
         for i, ax in enumerate(self.axs):
             if ylims is not None:
                 ax.set_ylim(ylims[::-1][i//ncols])
+                ax.get_shared_y_axes().join(ax, first_col[i // ncols])
             if xlims is not None:
                 ax.set_xlim(xlims[i % ncols])
+                ax.get_shared_x_axes().join(ax, last_row[i % ncols])
         self.standardize_ticks()
         if d:
             self.draw_diags()


### PR DESCRIPTION
This PR allows to interactively drag the axes and so move xlims and ylims. It progates it to the according row/col.

Here is an example:

```py
df = pd.DataFrame(data=pd.np.random.rand(500,2))

bax = brokenaxes(ylims=((0,0.4), (0.5,0.6), (0.8,1)), xlims=[(0, 0.3), (0.6,1)]) 
bax.scatter(df[0], df[1])
```

![sharing](https://user-images.githubusercontent.com/25247745/56037200-07f73b80-5d2f-11e9-8471-38e11066ec44.gif)
