### PR TITLE
Include licence file in distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENCE README.md
+recursive-include examples *.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_files = LICENCE


### PR DESCRIPTION
This PR modifies the package metadata to include the `LICENCE` file in distributions (`setup.cfg` for wheels, `MANIFEST.in` for tarballs).

I took the liberty of also adding the examples to the tarballs, they may be useful in testing that downstream distributions (e.g. conda packages) work properly.