### PR TITLE
fix issue with custom handles or labels in legend

### DIFF
--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -330,7 +330,7 @@ class BrokenAxes:
         return self.big_ax.set_title(*args, **kwargs)
 
     def legend(self, *args, **kwargs):
-        handles, lables = self.axs[0].get_legend_handles_labels()
+        handles, labels = self.axs[0].get_legend_handles_labels()
         if 'handles' in kwargs:
             handles = kwargs.pop('handles')
         if 'labels' in kwargs:

--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -330,8 +330,12 @@ class BrokenAxes:
         return self.big_ax.set_title(*args, **kwargs)
 
     def legend(self, *args, **kwargs):
-        h, l = self.axs[0].get_legend_handles_labels()
-        return self.big_ax.legend(h, l, *args, **kwargs)
+        handles, lables = self.axs[0].get_legend_handles_labels()
+        if 'handles' in kwargs:
+            handles = kwargs.pop('handles')
+        if 'labels' in kwargs:
+            labels = kwargs.pop('labels')
+        return self.big_ax.legend(handles, labels, *args, **kwargs)
 
     def axis(self, *args, **kwargs):
         [ax.axis(*args, **kwargs) for ax in self.axs]


### PR DESCRIPTION
Changes to the legend function are made so that an issue with
custom labels or handles is removed. Beforehand, the kwargs would
interfere with the positional arguments and a warning was given.
Now, custom handles and / or labels kwargs override the default values
retrieved from axs[0] and are popped from the kwargs dict, before it
gets passed to the wrapped legend function.