### PR TITLE
compare xlims to None explicitly

### DIFF
--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -93,7 +93,7 @@ class BrokenAxes:
                 width_ratios = [tt.total_seconds() for tt in width_ratios]
 
         if height_ratios is None:
-            if ylims:
+            if ylims is not None:
                 # Check if the user has asked for a log scale on y axis
                 if yscale == "log":
                     height_ratios = [np.log(i[1]) - np.log(i[0]) for i in ylims[::-1]]

--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -79,7 +79,7 @@ class BrokenAxes:
             self.fig = fig
 
         if width_ratios is None:
-            if xlims:
+            if xlims is not None:
                 # Check if the user has asked for a log scale on x axis
                 if xscale == "log":
                     width_ratios = [np.log(i[1]) - np.log(i[0]) for i in xlims]

--- a/test.py
+++ b/test.py
@@ -101,3 +101,8 @@ def test_text_error():
     )
     with pytest.raises(ValueError):
         bax.text(-11, -11, "hello")
+
+
+def test_lims_arrays():
+    lims = np.arange(6).reshape((-1,2))
+    brokenaxes(xlims=lims, ylims=lims)


### PR DESCRIPTION
For array input of xlims, `if xlims` fails, although the following code works perfectly fine, provided the array has the correct shape.