### PR TITLE
Replace `GrouperView.join` to `sharex`/`sharey`

### DIFF
--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -149,10 +149,10 @@ class BrokenAxes:
         for i, ax in enumerate(self.axs):
             if ylims is not None:
                 ax.set_ylim(ylims[::-1][i // ncols])
-                ax.get_shared_y_axes().join(ax, self.first_col[i // ncols])
+                ax.sharey(self.first_col[i // ncols])
             if xlims is not None:
                 ax.set_xlim(xlims[i % ncols])
-                ax.get_shared_x_axes().join(ax, self.last_row[i % ncols])
+                ax.sharex(self.last_row[i % ncols])
         self.standardize_ticks()
         if d:
             self.draw_diags()


### PR DESCRIPTION
As is mentioned in https://github.com/bendichter/brokenaxes/pull/96 , `GrouperView.join` has been deprecated.
But https://github.com/bendichter/brokenaxes/pull/96 's solution does not work: when trying examples in https://github.com/bendichter/brokenaxes,  it says

>   sharey
>     raise ValueError("y-axis is already shared")
> ValueError: y-axis is already shared

So I swapped `ax` with `self.first_col[i // ncols]`/`self.last_row[i % ncols]` and now it works.