### PR TITLE
Initialize `self.diag_handles` earlier to avoid overwriting initial diagonals

### DIFF
--- a/brokenaxes.py
+++ b/brokenaxes.py
@@ -125,10 +125,10 @@ class BrokenAxes:
                 ax.set_xlim(xlims[i % ncols])
                 ax.sharex(self.last_row[i % ncols])
         self.standardize_ticks()
+        self.diag_handles = []
         if d:
             self.draw_diags()
         self.set_spines()
-        self.diag_handles = []
 
     def _calculate_ratios(self, lims, scale):
         """


### PR DESCRIPTION
`self.diag_handles` is set to the empty list when initializing the module, per https://github.com/bendichter/brokenaxes/commit/582f0672b0c894bb2eeba4da74e988a944683f13

However, it seems to me this is done too late, i.e., only after the first call to `self.draw_diags()`, where `self.diag_handles` is also set to the diagonals that were created there. 
This means that the later `self.diag_handles = []` overwrites that list and effectively makes those diagonals inaccessible (e.g., crucially breaking `[x.remove() for x in bax.diag_handles]` in the example at https://github.com/bendichter/brokenaxes/tree/master?tab=readme-ov-file#datetime)